### PR TITLE
need to make subnet apply public ip by default

### DIFF
--- a/AWSVPCEC2LAtemplate
+++ b/AWSVPCEC2LAtemplate
@@ -280,6 +280,7 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "CidrBlock": "10.0.0.0/24",
+        "MapPublicIpOnLaunch": "true",
         "VpcId": {
           "Ref": "VPC"
         }


### PR DESCRIPTION
without MapPublicIpOnLaunch: true the WebServerInstance fails when creating the stack